### PR TITLE
Added ability to mount additional shared folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ docker run -d --name soulseek --restart=always \
 -v "/persistent/appdata":"/data/.SoulseekQt" \
 -v "/persistent/downloads":"/data/Soulseek Downloads" \
 -v "/persistent/logs":"/data/Soulseek Chat Logs" \
+-v "/persistent/shared":"/data/Soulseek Shared Folder" \
 -e pgid=1000 \
 -e puid=1000 \
 -e resize=scale \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - appdata:/data/.SoulseekQt
       - downloads:/data/Soulseek Downloads
       - logs:/data/Soulseek Chat Logs
+      - shared:/data/Soulseek Shared Folder
 volumes:
   appdata:
   downloads:
   logs:
+  shared:


### PR DESCRIPTION
Hello! A little change from me - I added the ability to mount an additional shared folder. It should be useful when our shares are stored outside the Soulseek download directory.