### PR TITLE
Fix build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 COPY ui.patch /tmp
 RUN apt-get update && \
- apt-get install -y binutils ca-certificates curl dbus libssl1.0-dev locales openbox patch supervisor x11vnc xvfb --no-install-recommends && \
+ apt-get install -y binutils ca-certificates curl dbus libssl1.0-dev locales openbox patch supervisor x11vnc xvfb python3 --no-install-recommends && \
  dbus-uuidgen > /etc/machine-id && \
  locale-gen en_US.UTF-8 && \
  mkdir /usr/share/novnc && \

--- a/init.sh
+++ b/init.sh
@@ -37,7 +37,7 @@ autorestart=true
 priority=300
 
 [program:novnc]
-command=/usr/share/novnc/utils/launch.sh
+command=/usr/share/novnc/utils/novnc_proxy
 autorestart=true
 priority=400
 


### PR DESCRIPTION
The current build process is broken because novnc changed their [scripts](https://github.com/novnc/noVNC/tree/master/utils). `launch.sh` has been renamed to `novnc_proxy`, and it now requires `python3` which was added as a dependency in the `Dockerfile`.

I tested that `docker-compose up --build` properly built and ran the image on a `amd64` machine.