### PR TITLE
add arm64 support via box64 emulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
           base-image: "ubuntu:latest"
           image: "realies/soulseek:latest"
 
+      - name: Set up QEMU
+        if: github.event_name == 'push' || steps.image_update_check.outputs.needs-updating == 'true'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: github.event_name == 'push' || steps.image_update_check.outputs.needs-updating == 'true'
         uses: docker/setup-buildx-action@v3
@@ -33,17 +37,33 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Docker Image
+      - name: Build and Push AMD64 Image
         if: github.event_name == 'push' || steps.image_update_check.outputs.needs-updating == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: realies/soulseek:latest
-          builder: ${{ steps.buildx.outputs.name }}
+          tags: realies/soulseek:amd64
           platforms: linux/amd64
+
+      - name: Build and Push ARM64 Image
+        if: github.event_name == 'push' || steps.image_update_check.outputs.needs-updating == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.arm64
+          push: true
+          tags: realies/soulseek:arm64
+          platforms: linux/arm64
+
+      - name: Create and Push Multi-Arch Manifest
+        if: github.event_name == 'push' || steps.image_update_check.outputs.needs-updating == 'true'
+        run: |
+          docker buildx imagetools create -t realies/soulseek:latest \
+            realies/soulseek:amd64 \
+            realies/soulseek:arm64
 
       - name: Docker Image Digest
         if: steps.image_update_check.outputs.needs-updating == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: docker buildx imagetools inspect realies/soulseek:latest

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,85 @@
+FROM --platform=linux/arm64 ubuntu:latest
+
+COPY ui.patch /tmp
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y ca-certificates curl dbus fonts-noto-cjk locales libegl1 openbox patch tigervnc-standalone-server tigervnc-tools tzdata xz-utils gnupg wget \
+    # For extracting AppImage during build and websockify
+    squashfs-tools python3 \
+    # Native ARM64 X11/XCB libraries for Box64 to use - these resolve symbol dependencies
+    libxcb-render0 libxcb-render-util0 libxcb-xkb1 libxcb-icccm4 libxcb-image0 \
+    libxcb-keysyms1 libxcb-randr0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 \
+    libxcb-cursor0 libxkbcommon0 libxkbcommon-x11-0 \
+    --no-install-recommends && \
+    dbus-uuidgen > /etc/machine-id && \
+    locale-gen en_US.UTF-8 && \
+    # Install Box64 from Pi-Apps-Coders repository for x86_64 emulation
+    mkdir -p /usr/share/keyrings && \
+    wget -qO- "https://pi-apps-coders.github.io/box64-debs/KEY.gpg" | gpg --dearmor -o /usr/share/keyrings/box64-archive-keyring.gpg && \
+    echo "Types: deb\nURIs: https://Pi-Apps-Coders.github.io/box64-debs/debian\nSuites: ./\nSigned-By: /usr/share/keyrings/box64-archive-keyring.gpg" > /etc/apt/sources.list.d/box64.sources && \
+    apt-get update && \
+    apt-get install -y box64-generic-arm && \
+    # s6-overlay for ARM64
+    curl -fL# https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-noarch.tar.xz -o /tmp/s6-overlay-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
+    rm -rf /tmp/s6-overlay-noarch.tar.xz && \
+    curl -fL# https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-aarch64.tar.xz -o /tmp/s6-overlay-aarch64.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-aarch64.tar.xz && \
+    rm -rf /tmp/s6-overlay-aarch64.tar.xz && \
+    # noVNC setup
+    mkdir /usr/share/novnc && \
+    curl -fL# https://github.com/novnc/noVNC/archive/master.tar.gz -o /tmp/novnc.tar.gz && \
+    tar -xf /tmp/novnc.tar.gz --strip-components=1 -C /usr/share/novnc && \
+    mkdir /usr/share/novnc/utils/websockify && \
+    curl -fL# https://github.com/novnc/websockify/archive/master.tar.gz -o /tmp/websockify.tar.gz && \
+    tar -xf /tmp/websockify.tar.gz --strip-components=1 -C /usr/share/novnc/utils/websockify && \
+    curl -fL# https://site-assets.fontawesome.com/releases/v6.0.0/svgs/solid/cloud-arrow-down.svg -o /usr/share/novnc/app/images/downloads.svg && \
+    curl -fL# https://site-assets.fontawesome.com/releases/v6.0.0/svgs/solid/folder-music.svg -o /usr/share/novnc/app/images/shared.svg && \
+    curl -fL# https://site-assets.fontawesome.com/releases/v6.0.0/svgs/solid/comments.svg -o /usr/share/novnc/app/images/logs.svg && \
+    bash -c 'sed -i "s/<path/<path style=\"fill:white\"/" /usr/share/novnc/app/images/{downloads,logs,shared}.svg' && \
+    patch /usr/share/novnc/vnc.html < /tmp/ui.patch && \
+    sed -i 's/10px 0 5px/8px 0 6px/' /usr/share/novnc/app/styles/base.css && \
+    ln -s /app/default.png /usr/share/novnc/app/images/soulseek.png && \
+    ln -s /data/Soulseek\ Downloads /usr/share/novnc/downloads && \
+    ln -s /data/Soulseek\ Shared\ Folder /usr/share/novnc/shared && \
+    ln -s /data/Soulseek\ Chat\ Logs /usr/share/novnc/logs && \
+    # Download x86_64 Soulseek AppImage (will run via Box64)
+    curl -fL# 'https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30.AppImage' -o /tmp/SoulseekQt-2024-6-30.AppImage && \
+    # Extract AppImage using unsquashfs (native tool, works during cross-compile build)
+    # SquashFS offset for SoulseekQt-2024-6-30.AppImage is 189632 bytes
+    tail -c +189633 /tmp/SoulseekQt-2024-6-30.AppImage > /tmp/appimage.squashfs && \
+    unsquashfs -d /app /tmp/appimage.squashfs && \
+    rm -f /tmp/appimage.squashfs /tmp/SoulseekQt-2024-6-30.AppImage && \
+    # Create a wrapper script for SoulseekQt that uses box64
+    mv /app/SoulseekQt /app/SoulseekQt.x86_64 && \
+    printf '#!/bin/bash\nexport BOX64_LD_LIBRARY_PATH=/app/lib:$BOX64_LD_LIBRARY_PATH\nexport BOX64_LOG=0\nexec /usr/local/bin/box64 /app/SoulseekQt.x86_64 "$@"\n' > /app/SoulseekQt && \
+    chmod +x /app/SoulseekQt && \
+    # User setup
+    userdel -f $(id -nu 1000) || true && \
+    groupdel -f $(id -ng 1000) || true && \
+    rm -rf /home && \
+    useradd -u 1000 -U -d /data -s /bin/false soulseek && \
+    usermod -G users soulseek && \
+    mkdir /data && \
+    # Cleanup
+    apt-get purge -y curl dbus patch xz-utils gnupg wget squashfs-tools && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DISPLAY=:1 \
+    HOME=/tmp \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    VNC_PORT=5900 \
+    NOVNC_PORT=6080 \
+    PGID=1000 \
+    PUID=1000 \
+    UMASK=022 \
+    MODIFY_VOLUMES=true \
+    XDG_RUNTIME_DIR=/tmp
+
+COPY rootfs /
+
+ENTRYPOINT ["/init"]

--- a/README.md
+++ b/README.md
@@ -1,105 +1,76 @@
-# Soulseek Docker Container
+# Soulseek Docker
 
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/realies/soulseek-docker?style=flat-square&logo=git&label=last%20commit)](https://github.com/realies/soulseek-docker/commits/main)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/realies/soulseek-docker/build.yml?style=flat-square&logo=github&label=build)](https://github.com/realies/soulseek-docker/actions)
-[![Docker Pulls](https://img.shields.io/docker/pulls/realies/soulseek?style=flat-square&logo=docker&label=pulls)](https://hub.docker.com/r/realies/soulseek)
-[![Docker Image Size](https://img.shields.io/docker/image-size/realies/soulseek?style=flat-square&logo=docker&label=size)](https://hub.docker.com/r/realies/soulseek)
+[![Build](https://img.shields.io/github/actions/workflow/status/realies/soulseek-docker/build.yml?style=flat-square&logo=github)](https://github.com/realies/soulseek-docker/actions)
+[![Pulls](https://img.shields.io/docker/pulls/realies/soulseek?style=flat-square&logo=docker)](https://hub.docker.com/r/realies/soulseek)
+[![Size](https://img.shields.io/docker/image-size/realies/soulseek?style=flat-square&logo=docker)](https://hub.docker.com/r/realies/soulseek)
 
-![Soulseek Docker Container Screenshot](https://i.snag.gy/8dpAbV.jpg)
+Soulseek client running in Docker with web-based access via noVNC.
 
-## Prerequisites
+![Screenshot](https://i.snipboard.io/8dpAbV.jpg)
 
-- Docker installed on your machine or server
-- Port 6080 open and accessible for noVNC web access (or reverse proxied, nginx example at `soulseek.conf`)
-- Ports required by Soulseek open and forwarded from your router to the Docker host machine
-
-## Setup
-
-1. Map port 6080 on the host machine to port 6080 on the Docker container.
-
-- If using a GUI or webapp (e.g., Synology) to manage Docker containers, set this configuration option when launching the container from the image.
-- With Docker CLI, use the `-p 6080:6080` option.
-
-2. Map the ports Soulseek uses on the Docker container.
-
-- The first time it runs, Soulseek starts up using a random port. It can also be manually configured in Options -> Login.
-- Wait for a Soulseek settings file to appear in `/data/.SoulseekQt/1`, this is saved every 60 minutes by default but can be forced to be more freuquent from Options -> General.
-- Map both ports from your router to the machine hosting the Docker image, and from the outside of the Docker image to the server within it. See the [Soulseek FAQ](https://www.slsknet.org/news/faq-page#t10n606) for more details.
-
-3. Launch the Docker container and map the required volumes (see [How to Launch](#how-to-launch) section below).
-
-4. Access the Soulseek UI by opening a web browser and navigating to `http://docker-host-ip:6080` or `https://reverse-proxy`, depending on your configuration.
-
-## Configuration
-
-The container supports the following configuration options:
-
-| Parameter       | Description                                                                   |
-| --------------- | ----------------------------------------------------------------------------- |
-| `PGID`          | Group ID for the container user (optional, requires `PUID`, default: 1000)    |
-| `PUID`          | User ID for the container user (optional, requires `PGID`, default: 1000)     |
-| `VNC_PORT`      | Port for VNC server (optional, default: 5900)                                 |
-| `NOVNC_PORT`    | Port for noVNC web access (optional, default: 6080)                           |
-| `MODIFY_VOLUMES`| Modify ownership and permissions of mounted volumes (optional, default: true) |
-| `UMASK`         | File permission mask for newly created files (optional, default: 022)         |
-| `VNCPWD`        | Password for the VNC connection (optional)                                    |
-| `VNCPWD_FILE`   | Password file for the VNC connection (optional, takes priority over `VNCPWD`) |
-| `TZ`            | Timezone for the container (optional, e.g., Europe/Paris, America/Vancouver)  |
-
-## How to Launch
-
-### Using Docker Compose
+## Quick Start
 
 ```yaml
-version: "3"
 services:
   soulseek:
     image: realies/soulseek
     container_name: soulseek
     restart: unless-stopped
-    volumes:
-      - /persistent/appdata:/data/.SoulseekQt
-      - /persistent/downloads:/data/Soulseek Downloads
-      - /persistent/logs:/data/Soulseek Chat Logs
-      - /persistent/shared:/data/Soulseek Shared Folder
-    environment:
-      - PGID=1000
-      - PUID=1000
     ports:
       - 6080:6080
-      - 61122:61122 # example listening port, check Options -> Login
-      - 61123:61123 # example obfuscated port, check Options -> Login
+    volumes:
+      - ./appdata:/data/.SoulseekQt
+      - ./downloads:/data/Soulseek Downloads
+      - ./shared:/data/Soulseek Shared Folder
 ```
 
-### Using Docker CLI
+Access the UI at `http://localhost:6080`
 
-```bash
-docker run -d --name soulseek --restart=unless-stopped \
-  -v "/persistent/appdata":"/data/.SoulseekQt" \
-  -v "/persistent/downloads":"/data/Soulseek Downloads" \
-  -v "/persistent/logs":"/data/Soulseek Chat Logs" \
-  -v "/persistent/shared":"/data/Soulseek Shared Folder" \
-  -e PGID=1000 \
-  -e PUID=1000 \
-  -p 6080:6080 \
-  -p 61122:61122 \ # example listening port, check Options -> Login
-  -p 61123:61123 \ # example obfuscated port, check Options -> Login
-  realies/soulseek
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUID` | `1000` | User ID |
+| `PGID` | `1000` | Group ID |
+| `UMASK` | `022` | File permission mask |
+| `TZ` | - | Timezone (e.g., `America/New_York`) |
+| `VNCPWD` | - | VNC password |
+| `VNCPWD_FILE` | - | Path to VNC password file |
+
+## Port Forwarding
+
+For full connectivity, forward your Soulseek listening ports:
+
+1. Start the container and open the UI
+2. Go to **Options → Login** to find your ports
+3. Forward those ports on your router to your Docker host
+4. Add them to your compose file:
+
+```yaml
+ports:
+  - 6080:6080
+  - 61122:61122  # listening port
+  - 61123:61123  # obfuscated port
 ```
 
-### Using Docker on Synology DSM
+## Volumes
 
-Port Configuration
+| Path | Description |
+|------|-------------|
+| `/data/.SoulseekQt` | Application data and settings |
+| `/data/Soulseek Downloads` | Downloaded files |
+| `/data/Soulseek Shared Folder` | Files to share |
+| `/data/Soulseek Chat Logs` | Chat history (optional) |
 
-![Synology Docker Port Configuration](docs/synology_docker_config_ports_screenshot.png)
+## Platform Support
 
-- Port 6080 is used by noVNC for accessing Soulseek from your local network. Only TCP type is needed.
-- Ports 61122 and 61123 are examples; open Soulseek to determine the exact ports to forward. Only TCP type is needed.
-- Configure these ports to forward from your router to the machine hosting the Docker image. See the Soulseek Port Forwarding Guide for more details.
+| Architecture | Support |
+|--------------|---------|
+| `linux/amd64` | Native |
+| `linux/arm64` | Via Box64 emulation |
 
-Volume Configuration
+ARM64 support enables running on Raspberry Pi, Apple Silicon, AWS Graviton, and other ARM devices.
 
-![Synology Docker Volume Configuration](docs/synology_docker_config_volumes_screenshot.png)
+## Reverse Proxy
 
-- Mount the required directories for Soulseek data persistence.
-- The example mounts an extra directory `/music/FLAC` for sharing; mount the directory you want to share.
+Example nginx configuration is available in [`soulseek.conf`](soulseek.conf).


### PR DESCRIPTION
## Summary
- Add `Dockerfile.arm64` for ARM64 builds using Box64 to run x86_64 Soulseek
- Update GitHub workflow to build both amd64 and arm64 images with multi-arch manifest
- Revamp README with cleaner layout and platform support section

## Platform Support
| Architecture | Support |
|--------------|---------|
| `linux/amd64` | Native |
| `linux/arm64` | Via Box64 emulation |

Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 platform support alongside AMD64, enabling unified multi-architecture container images.

* **Documentation**
  * Streamlined README with a quick start guide and simplified setup instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->