### PR TITLE
Disable TigerVNC blacklisting for containerized usage

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/svc-tigervnc/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/svc-tigervnc/run
@@ -11,12 +11,12 @@ fi
 if [ -z "${VNCPWD}" ]; then
   exec s6-setuidgid "$(id -nu "$PUID")" Xtigervnc \
     -desktop soulseek -auth /tmp/.Xauthority -rfbport "${VNC_PORT}" \
-    -nopn -quiet -AlwaysShared -SecurityTypes None :1
+    -nopn -quiet -AlwaysShared -UseBlacklist 0 -SecurityTypes None :1
 else
   [ "${#VNCPWD}" -gt 8 ] && echo "WARNING: VNC auth only uses the first 8 characters of VNCPWD" >&2
   (umask 077 && printf '%s\n' "${VNCPWD}" | vncpasswd -f > /tmp/passwd) || { echo "vncpasswd failed" >&2; exit 1; }
   chown "$(id -nu "$PUID")" /tmp/passwd
   exec s6-setuidgid "$(id -nu "$PUID")" Xtigervnc \
     -desktop soulseek -auth /tmp/.Xauthority -rfbport "${VNC_PORT}" \
-    -nopn -rfbauth /tmp/passwd -quiet -AlwaysShared :1
+    -nopn -rfbauth /tmp/passwd -quiet -AlwaysShared -UseBlacklist 0 :1
 fi


### PR DESCRIPTION
## Summary

TigerVNC blacklists IPs after 5 unauthenticated connection attempts (`BlacklistThreshold=5`). Since all VNC connections in this container come from the local websockify proxy on `127.0.0.1`, normal browser reconnections (tab close, network blip, navigate away and back) trigger the blacklist and break the noVNC web UI entirely.

Related: #114

## Root cause

Websockify opens a new TCP connection to `localhost:5900` for each browser session. TigerVNC counts the prior connection's disconnect as an unauthenticated attempt. After 5 reconnections, `127.0.0.1` is blacklisted and websockify can no longer reach VNC.

## Fix

Add `-UseBlacklist 0` to both the passwordless and password-protected Xtigervnc exec paths. The blacklist feature is designed for network-exposed VNC servers, not for a containerized setup where the only VNC client is the local websockify proxy.

## Test plan

- [x] 10 rapid TCP connect/disconnect cycles to VNC port — no blacklisting
- [x] Container stays healthy
- [x] Tested on arm64 host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VNC server startup configuration to adjust blacklist filtering settings for improved compatibility and connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->