### PR TITLE
Pin actions to SHAs and track them with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Actions are pinned to SHAs; Dependabot bumps the SHA and the `# vX.Y.Z`
+  # comment together, so pinning does not become manual maintenance.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
       should-build: ${{ steps.decide.outputs.should-build }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check if Base Image Updated
         id: image_update_check
         if: github.event_name == 'schedule'
-        uses: lucacome/docker-image-update-checker@v2
+        uses: lucacome/docker-image-update-checker@f97e2a3cdbf2d8f9788fb87081a76542645a4252 # v3.1.1
         with:
           base-image: "ubuntu:latest"
           image: "realies/soulseek:latest"
@@ -47,22 +47,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
@@ -79,13 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Create and Push Multi-Arch Manifest
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: "0 9 * * *"
 
+# Docker Hub credentials come from secrets, and the gha cache uses the runtime
+# token, so no job needs a write-capable GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow floated on major tags with no Dependabot config, so the actions drifted until every job logged Node 20 deprecation warnings.

## Changes

- Pin all nine action references to release SHAs with the version in a trailing comment.
- Add a `github-actions` ecosystem so Dependabot bumps the SHA and the comment together. Grouped weekly so updates land as one PR rather than six.
- `lucacome/docker-image-update-checker` v2 → v3.
- Set `permissions: contents: read`. The repository default is write, so every third-party action was handed a write-capable `GITHUB_TOKEN` it has no use for.

Pinning matters more here than in most repos: `docker/login-action` handles the Docker Hub token, and a floating tag can be repointed at any commit by whoever controls the action. The Dockerfile already verifies the Box64 GPG fingerprint and the SoulseekQt sha256, so floating action tags were the odd one out.

The checker bump is additive for this usage — same inputs, two extra outputs (`needs-building`, `diff-json`), and the major exists because the runtime moved from `node20` to `node24`, which is one of the deprecation warnings.

## Verification

Each pinned SHA was checked back against its tagged release via the API, and both YAML files parse.

`actions/checkout` v4 → v7 and the docker actions v3 → v4 are real majors; only the checker's interface was diffed in detail, so the build on merge is the actual test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build and release workflow reliability by using fixed, verified versions of build tools.
  - Added automated weekly maintenance checks for workflow components, with related updates grouped together for easier review.
- **Security**
  - Strengthened the software supply chain by making automated build processes more predictable and auditable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->